### PR TITLE
 🐛 bugfix: 모달창 데이터 렌더링이 정상 작동되지 않은 건 해결

### DIFF
--- a/src/script/modalRendering.ts
+++ b/src/script/modalRendering.ts
@@ -91,8 +91,21 @@ export function setupModalEvents(resources: Resource[]): void {
   const detailButtons = section.querySelectorAll<HTMLButtonElement>('button[name="detail"]');
   detailButtons.forEach((button) => {
     button.addEventListener('click', function () {
+      // resource 데이터를 필터링된 결과로 변경하는 기능 추가
+      const articles = section.querySelectorAll<HTMLElement>('article');
+      const articleTitles = Array.from(articles).map((article) => {
+        const h3 = article.querySelector('h3');
+        return h3 ? h3.textContent?.trim() : '';
+      });
+
+      // resource.json 데이터에서 id가 articleIds에 포함된 것만 필터링
+      const filteredResources = resources.filter((resource) =>
+        articleTitles.includes(resource.title),
+      );
+
       const resourceId = Number(this.closest('article')?.getAttribute('data-index'));
-      openModal(resources, resourceId);
+
+      openModal(filteredResources, resourceId);
     });
   });
 


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- data-index 로 데이터를 받아오는 로직을 확인해보니, resource 가 다시 렌더링되면 index 의 값도 초기화되어 다시 배정되는 이슈가 있었습니다.
- data-index 가 아닌, 해당 article 의 h3 텍스트로 데이터를 가져오는 방식으로 구현했더니 정상 작동됩니다.

## 이슈

none
